### PR TITLE
Fix global variable in banker ped management

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -58,6 +58,7 @@ local function TriggerServerCallback(name, callback, ...)
 end
 
 local bankerPed = nil
+local bankerPeds = {}
 local bankingOpen = false
 local nearbyATMs = {}
 local isUsingATM = false


### PR DESCRIPTION
## Summary
- fix leaking global `bankerPeds` table by declaring it local

## Testing
- `luacheck *.lua` *(fails: command not found)*

